### PR TITLE
Migrate student info schema from Markdown to HTML

### DIFF
--- a/text.html
+++ b/text.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+</head>
+
+<body>
+
+    <h2> fname , lname , email , phone </h2>
+
+    CREATE TABLE stud_basic_info (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    fname VARCHAR(100) NOT NULL,
+    lname VARCHAR(100) NOT NULL,
+    email VARCHAR(150) NOT NULL UNIQUE,
+    phone VARCHAR(15) NOT NULL
+    );
+
+    <p> INSERT INTO `stud_basic_info`( `fname`, `lname`, `email`, `phone`) VALUES
+        ('parmar','pradip','parmarparth@gmail.com','7103425012') </p>
+
+    <h2> gender, address1, address2, city , state, country, zip , resume </h2>
+
+    CREATE TABLE stud_gen_info (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    student_id INT NOT NULL,
+    gender ENUM('male', 'female', 'other') NOT NULL,
+    address1 VARCHAR(255),
+    address2 VARCHAR(255),
+    city VARCHAR(100),
+    state VARCHAR(100),
+    country VARCHAR(100),
+    zip VARCHAR(10),
+    photo VARCHAR(255),
+    FOREIGN KEY (student_id) REFERENCES stud_basic_info(id) ON DELETE CASCADE ON UPDATE CASCADE
+    );
+
+
+    <p>INSERT INTO `stud_gen_info`(`student_id`, `gender`, `address1`, `address2`, `city`, `state`, `country`, `zip`,
+        `photo`) VALUES ('54','male','Junagadh','Junagadh','Junagadh','Gujrat','India','235689','')</p>
+    <h2> qualification , percentage, passing year, university </h2>
+
+    CREATE TABLE qualifications (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    qualification_name VARCHAR(100) NOT NULL UNIQUE
+    );
+
+    <p>INSERT INTO `qualifications`( `qualification_name`)
+        VALUES
+        ('BCA'),
+        ('MCA'),
+        ('B.COM'),
+        ('M.COM'),
+        ('B.TECH'),
+        ('M.TECH');
+    </p>
+
+
+    CREATE TABLE stud_academic_info (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    student_id INT NOT NULL,
+    qualification_id INT NOT NULL,
+    percentage DECIMAL(5,2) NOT NULL,
+    passing_year YEAR NOT NULL,
+    university VARCHAR(150) NOT NULL,
+    FOREIGN KEY (student_id) REFERENCES stud_basic_info(id) ON DELETE CASCADE ON UPDATE CASCADE,
+    FOREIGN KEY (qualification_id) REFERENCES qualifications(id) ON DELETE CASCADE ON UPDATE CASCADE
+    );
+
+    <p>INSERT INTO `stud_academic_info`( `student_id`, `qualification_id`, `percentage`, `passing_year`, `university`)
+        VALUES ('54','3','67.36','2023',Mmarvadi University')</p>
+    <h2> Hobbies </h2>
+
+    CREATE TABLE hobbies (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    hobby_name VARCHAR(100) NOT NULL UNIQUE
+    );
+
+    </p>INSERT INTO `hobbies`( `hobby_name`)
+    VALUES
+    ('Gaming'),
+    ('Sports'),
+    ('Travel'),
+    ('Reading'),
+    ('Photography'),
+    ('Cooking/Baking');
+    </p>
+    CREATE TABLE stud_hobbies (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    student_id INT NOT NULL,
+    hobby_id INT NOT NULL,
+    FOREIGN KEY (student_id) REFERENCES stud_basic_info(id) ON DELETE CASCADE ON UPDATE CASCADE,
+    FOREIGN KEY (hobby_id) REFERENCES hobbies(id) ON DELETE CASCADE ON UPDATE CASCADE
+    );
+
+    <p>INSERT INTO `stud_hobbies`( `student_id`, `hobby_id`) VALUES ('54','3')</p>
+
+
+    <p>SELECT
+        sb.id AS student_id,
+        sb.fname,
+        sb.lname,
+        sb.email,
+        sb.phone,
+        sg.gender,
+        sg.address1,
+        sg.address2,
+        sg.city,
+        sg.state,
+        sg.country,
+        sg.zip,
+        sa.percentage,
+        sa.passing_year,
+        sa.university,
+        q.qualification_name,
+        GROUP_CONCAT(h.hobby_name SEPARATOR ', ') AS hobbies
+        FROM stud_basic_info sb
+        LEFT JOIN stud_gen_info sg ON sb.id = sg.student_id
+        LEFT JOIN stud_academic_info sa ON sb.id = sa.student_id
+        LEFT JOIN qualifications q ON sa.qualification_id = q.id
+        LEFT JOIN stud_hobbies sh ON sb.id = sh.student_id
+        LEFT JOIN hobbies h ON sh.hobby_id = h.id
+        GROUP BY sb.id;
+    </p>
+
+
+    <p>-> qualification (DYNAMIC) -> (BCA , MCA , B.COM , MCOM, B.TECH ,M.TECH, B.A , M.A , OTHERS )
+        IF USER CAN CLICK OTHERS THTA HE CAN SHOW INPUT FILED THAT ADD NEW qualification FOR THE USER AND THAT WAS
+        DYNAMIC ADDITON</p>
+
+    <p> -> Hobbies (Watching Movies/TV,Gaming,Writing/Blogging ,Sports ,Travel,Reading,Volunteering/Community
+        Involvement, Learning Languages ,Photography, Playing a Musical Instrument, Graphic Design/Digital Art
+        ,Cooking/Baking , Woodworking/DIY Projects , Coding/Programming , OTHERS ) => IF USER CAN CLICK OTHERS THTA HE
+        CAN SHOW INPUT FILED THAT ADD NEW qualification FOR THE USER AND THAT WAS DYNAMIC ADDITON </p>
+
+
+    <h5> fname </h5>
+    <h5> lname </h5>
+    <h5> email </h5>
+    <h5> phone </h5>
+    <h5> resume(photo upload) </h5>
+    <h5> gender </h5>
+    <h5> address1 </h5>
+    <h5> address2 </h5>
+    <h5> city </h5>
+    <h5> state </h5>
+    <h5> country </h5>
+    <h5> zip </h5>
+    <h5> qualification (DYNAMIC) </h5>
+    <h5> percentage </h5>
+    <h5> passing year </h5>
+    <h5> university </h5>
+    <h5> Hobbies (DYNAMIC) </h5>
+
+
+
+
+    <p>INSERT INTO `stud_basic_info`( `fname`, `lname`, `email`, `phone`) VALUES
+        ('parmar','pradip','parmarparth@gmail.com','7103425012')</p>
+    <p>INSERT INTO `stud_gen_info`(`student_id`, `gender`, `address1`, `address2`, `city`, `state`, `country`, `zip`,
+        `photo`) VALUES ('54','male','Junagadh','Junagadh','Junagadh','Gujrat','India','235689','')</p>
+    <p>INSERT INTO `stud_academic_info`( `student_id`, `qualification_id`, `percentage`, `passing_year`, `university`)
+        VALUES ('54','3','67.36','2023',Mmarvadi University')</p>
+    <p>INSERT INTO `stud_hobbies`( `student_id`, `hobby_id`) VALUES ('54','3')</p>
+
+
+
+
+    <p>DELETE FROM stud_basic_info;
+        ALTER TABLE stud_basic_info AUTO_INCREMENT = 1;</p>
+
+</body>
+
+</html>


### PR DESCRIPTION
Replaces text.md with text.html, converting the student information database schema, sample queries, and notes from Markdown to HTML format. This change improves readability and presentation for web-based documentation.